### PR TITLE
fix(persona): fix member creation duplicate check

### DIFF
--- a/src/persona/persona.service.ts
+++ b/src/persona/persona.service.ts
@@ -72,7 +72,9 @@ export class PersonaService {
   async crearMiembro(dto: CrearMiembroDto): Promise<Miembro> {
     const { historial, ...data } = dto;
 
-    const miembroExiste = this.verificarSiMiembroExiste({ cedula: data.cedula, nombre_completo: data.nombre_completo });
+    const miembroExiste = await this.verificarSiMiembroExiste({ cedula: data.cedula, nombre_completo: data.nombre_completo });
+
+    console.log(miembroExiste);
 
     if(miembroExiste) {
       throw new HttpException('Ya existe un miembro con la misma cedula o nombre completo', HttpStatus.BAD_REQUEST);
@@ -200,6 +202,6 @@ export class PersonaService {
     cedula: string;
     nombre_completo: string;
   }): Promise<boolean> {
-    return await this.miembroRepository.existsBy({ ...options });
+    return await this.miembroRepository.existsBy([{ cedula: options.cedula }, { nombre_completo: options.nombre_completo }]);
   }
 }


### PR DESCRIPTION
Fixes an issue where the duplicate check for member creation was not working correctly. The `verificarSiMiembroExiste` method now correctly awaits the check and logs the result. Additionally, the `existsBy` method in the `miembroRepository` now accepts an array of options for more flexible querying.

Closes #7